### PR TITLE
Take into consideration not determined status into checking notifications access status

### DIFF
--- a/swift-sdk/Internal/InternalIterableAppIntegration.swift
+++ b/swift-sdk/Internal/InternalIterableAppIntegration.swift
@@ -16,7 +16,8 @@ protocol NotificationStateProviderProtocol {
 struct SystemNotificationStateProvider: NotificationStateProviderProtocol {
     func isNotificationsEnabled(withCallback callback: @escaping (Bool) -> Void) {
         UNUserNotificationCenter.current().getNotificationSettings { setttings in
-            callback(setttings.authorizationStatus != .denied)
+            let notificationsDisabled = setttings.authorizationStatus == .notDetermined || setttings.authorizationStatus == .denied
+            callback(!notificationsDisabled)
         }
     }
     


### PR DESCRIPTION
## ✏️ Description

```swift
let config = IterableConfig()
config.autoPushRegistration = false
IterableAPI.initialize(apiKey: apiKey, launchOptions: launchOptions, config: config)
```

If you take into consideration that the user has `autoPushRegistration` set to false, the SDK will return `notificationsEnabled` set to true due to this bug. If `autoPushRegistration` is set to false, the user often has `UNAuthorizationStatus` set to `.notDetermined`.  


This change fixes this issue so that by default SDK should return the proper value