### PR TITLE
[MOB-9974] fix event replay from visitor to known user

### DIFF
--- a/swift-sdk/Internal/AnonymousUserManager.swift
+++ b/swift-sdk/Internal/AnonymousUserManager.swift
@@ -143,7 +143,7 @@ public class AnonymousUserManager: AnonymousUserManagerProtocol {
     }
     
     // Syncs locally saved data through track APIs
-    private func syncEvents() {
+    public func syncEvents() {
         let events = localStorage.anonymousUserEvents
         var successfulSyncedData: [Int] = []
         

--- a/swift-sdk/Internal/AnonymousUserManagerProtocol.swift
+++ b/swift-sdk/Internal/AnonymousUserManagerProtocol.swift
@@ -13,5 +13,5 @@ import Foundation
     func trackAnonUpdateUser(_ dataFields: [AnyHashable: Any])
     func updateAnonSession()
     func getAnonCriteria()
-    func syncNonSyncedEvents()
+    func syncEvents()
 }

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -137,13 +137,6 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         let merge = identityResolution?.mergeOnAnonymousToKnown ?? config.identityResolution.mergeOnAnonymousToKnown
         let replay = identityResolution?.replayOnVisitorToKnown ?? config.identityResolution.replayOnVisitorToKnown
         
-        if(config.enableAnonTracking) {
-            if(email != nil) {
-                attemptAndProcessMerge(merge: merge ?? true, replay: replay ?? true, destinationUser: email, isEmail: true, failureHandler: failureHandler)
-            }
-            self.localStorage.userIdAnnon = nil
-        }
-        
         if self._email == email && email != nil {
             self.checkAndUpdateAuthToken(authToken)
             return
@@ -158,6 +151,13 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         self._email = email
         self._userId = nil
         
+        if(config.enableAnonTracking) {
+            if(email != nil) {
+                attemptAndProcessMerge(merge: merge ?? true, replay: replay ?? true, destinationUser: email, isEmail: true, failureHandler: failureHandler)
+            }
+            self.localStorage.userIdAnnon = nil
+        }
+        
         self._successCallback = successHandler
         self._failureCallback = failureHandler
         self.storeIdentifierData()
@@ -171,16 +171,6 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         let merge = identityResolution?.mergeOnAnonymousToKnown ?? config.identityResolution.mergeOnAnonymousToKnown
         let replay = identityResolution?.replayOnVisitorToKnown ?? config.identityResolution.replayOnVisitorToKnown
         
-        if(config.enableAnonTracking) {
-            if(userId != nil && userId != localStorage.userIdAnnon) {
-                attemptAndProcessMerge(merge: merge ?? true, replay: replay ?? true, destinationUser: userId, isEmail: false, failureHandler: failureHandler)
-            }
-
-            if(!isAnon) {
-                self.localStorage.userIdAnnon = nil
-            }
-        }
-   
         if self._userId == userId && userId != nil {
             self.checkAndUpdateAuthToken(authToken)
             return
@@ -194,6 +184,16 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         
         self._email = nil
         self._userId = userId
+        
+        if(config.enableAnonTracking) {
+            if(userId != nil && userId != localStorage.userIdAnnon) {
+                attemptAndProcessMerge(merge: merge ?? true, replay: replay ?? true, destinationUser: userId, isEmail: false, failureHandler: failureHandler)
+            }
+
+            if(!isAnon) {
+                self.localStorage.userIdAnnon = nil
+            }
+        }
         
         self._successCallback = successHandler
         self._failureCallback = failureHandler
@@ -210,7 +210,7 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
             
             if mergeResult == MergeResult.mergenotrequired ||  mergeResult == MergeResult.mergesuccessful {
                 if (replay) {
-                    self.anonymousUserManager.syncNonSyncedEvents()
+                    self.anonymousUserManager.syncEvents()
                 }
             } else {
                 failureHandler?(error, nil)

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -151,13 +151,16 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         self._email = email
         self._userId = nil
         
-        if(config.enableAnonTracking) {
-            if(email != nil) {
-                attemptAndProcessMerge(merge: merge ?? true, replay: replay ?? true, destinationUser: email, isEmail: true, failureHandler: failureHandler)
-            }
+        if config.enableAnonTracking, let email = email {
+            attemptAndProcessMerge(
+                merge: merge ?? true,
+                replay: replay ?? true,
+                destinationUser: email,
+                isEmail: true,
+                failureHandler: failureHandler
+            )
             self.localStorage.userIdAnnon = nil
         }
-        
         self._successCallback = successHandler
         self._failureCallback = failureHandler
         self.storeIdentifierData()

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -188,13 +188,19 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         self._email = nil
         self._userId = userId
         
-        if(config.enableAnonTracking) {
-            if(userId != nil && userId != localStorage.userIdAnnon) {
-                attemptAndProcessMerge(merge: merge ?? true, replay: replay ?? true, destinationUser: userId, isEmail: false, failureHandler: failureHandler)
+        if config.enableAnonTracking {
+            if let userId = userId, userId != localStorage.userIdAnnon {
+                attemptAndProcessMerge(
+                    merge: merge ?? true,
+                    replay: replay ?? true,
+                    destinationUser: userId,
+                    isEmail: false,
+                    failureHandler: failureHandler
+                )
             }
-
-            if(!isAnon) {
-                self.localStorage.userIdAnnon = nil
+            
+            if !isAnon {
+                localStorage.userIdAnnon = nil
             }
         }
         

--- a/tests/unit-tests/UserMergeScenariosTests.swift
+++ b/tests/unit-tests/UserMergeScenariosTests.swift
@@ -109,9 +109,9 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
                }
         
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+                    XCTFail("Events are not replayed")
                } else {
-                   XCTFail("Expected events to be logged but found nil")
+                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
                }
  
         // Verify "merge user" API call is not made
@@ -504,9 +504,9 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
                }
         
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+                    XCTFail("Events are not replayed")
                } else {
-                   XCTFail("Expected events to be logged but found nil")
+                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
                }
  
         // Verify "merge user" API call is not made

--- a/tests/unit-tests/ValidateStoredEventCheckUnknownToKnownUserTest.swift
+++ b/tests/unit-tests/ValidateStoredEventCheckUnknownToKnownUserTest.swift
@@ -59,9 +59,9 @@ final class ValidateStoredEventCheckUnknownToKnownUserTest: XCTestCase, AuthProv
         IterableAPI.setUserId("testuser123")
 
         if let events = self.localStorage.anonymousUserEvents {
-            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+            XCTFail("Events are not replayed")
         } else {
-           XCTFail("Expected events to be logged but found nil")
+            XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
         }
 
         self.waitForDuration(seconds: 3)


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-9974](https://iterable.atlassian.net/browse/MOB-9974)

## ✏️ Description

> This pull request updates attemptAndProcessMerge to call syncEvents directly. Also, modifies flow to set userId/email before attempting event replay.


[MOB-9974]: https://iterable.atlassian.net/browse/MOB-9974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ