### PR TITLE
[MOB-9646] update UserMergeScenarioTests to include all identity resolution parameter combinations

### DIFF
--- a/tests/unit-tests/UserMergeScenariosTests.swift
+++ b/tests/unit-tests/UserMergeScenariosTests.swift
@@ -16,7 +16,7 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
     private let dateProvider = MockDateProvider()
     let mockSession = MockNetworkSession(statusCode: 200)
     let localStorage = MockLocalStorage()
-
+    
     var auth: Auth {
         Auth(userId: nil, email: nil, authToken: authToken, userIdAnon: nil)
     }
@@ -30,9 +30,9 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
     }
     
     override func tearDown() {
-           // Clean up after each test
-           super.tearDown()
-       }
+        // Clean up after each test
+        super.tearDown()
+    }
     
     let mockData = """
     {
@@ -87,389 +87,397 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
         let config = IterableConfig()
         config.enableAnonTracking = true
         IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent123")
-       
+        
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-               } else {
-                   XCTFail("Expected events to be logged but found nil")
-               }
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+        } else {
+            XCTFail("Expected events to be logged but found nil")
+        }
         
         IterableAPI.setUserId("testuser123")
         if let userId = IterableAPI.userId {
             XCTAssertEqual(userId, "testuser123", "Expected userId to be 'testuser123'")
-               } else {
-                   XCTFail("Expected userId but found nil")
-               }
+        } else {
+            XCTFail("Expected userId but found nil")
+        }
         waitForDuration(seconds: 5)
-
-        if let events = localStorage.anonymousUserEvents {
-                XCTFail("Events are not replayed")
-            } else {
-                XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
-            }
- 
+        
+        if localStorage.anonymousUserEvents != nil {
+            XCTFail("Events are not replayed")
+        } else {
+            XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
+        }
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaNotMetUserIdReplayTrueMergeFalse() {  // criteria not met with merge false with setUserId
         let config = IterableConfig()
         config.enableAnonTracking = true
         IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
+        
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent123")
-       
+        
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-               } else {
-                   XCTFail("Expected events to be logged but found nil")
-               }
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+        } else {
+            XCTFail("Expected events to be logged but found nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: true, mergeOnAnonymousToKnown: false)
         IterableAPI.setUserId("testuser123", nil, identityResolution)
         if let userId = IterableAPI.userId {
             XCTAssertEqual(userId, "testuser123", "Expected userId to be 'testuser123'")
-               } else {
-                   XCTFail("Expected userId but found nil")
-               }
+        } else {
+            XCTFail("Expected userId but found nil")
+        }
         
-        if let events = localStorage.anonymousUserEvents {
-                    XCTFail("Events are not replayed")
-               } else {
-                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
-               }
- 
+        if localStorage.anonymousUserEvents != nil {
+            XCTFail("Events are not replayed")
+        } else {
+            XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
+        }
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaNotMetUserIdReplayFalseMergeFalse() {  // criteria not met with merge true with setUserId
         let config = IterableConfig()
         config.enableAnonTracking = true
         IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
+        
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent123")
-       
+        
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-               } else {
-                   XCTFail("Expected events to be logged but found nil")
-               }
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+        } else {
+            XCTFail("Expected events to be logged but found nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: false, mergeOnAnonymousToKnown: false)
         IterableAPI.setUserId("testuser123", nil, identityResolution)
         
         if let userId = IterableAPI.userId {
             XCTAssertEqual(userId, "testuser123", "Expected userId to be 'testuser123'")
-               } else {
-                   XCTFail("Expected userId but found nil")
-               }
+        } else {
+            XCTFail("Expected userId but found nil")
+        }
         waitForDuration(seconds: 5)
-
+        
         if let events = localStorage.anonymousUserEvents {
-                XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-            } else {
-                XCTFail("Events were incorrectly cleared")
-            }
- 
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+        } else {
+            XCTFail("Events were incorrectly cleared")
+        }
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaNotMetUserIdReplayFalseMergeTrue() {  // criteria not met with merge true with setUserId
         let config = IterableConfig()
         config.enableAnonTracking = true
         IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
+        
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent123")
-       
+        
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-               } else {
-                   XCTFail("Expected events to be logged but found nil")
-               }
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+        } else {
+            XCTFail("Expected events to be logged but found nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: false, mergeOnAnonymousToKnown: true)
         IterableAPI.setUserId("testuser123", nil, identityResolution)
         
         if let userId = IterableAPI.userId {
             XCTAssertEqual(userId, "testuser123", "Expected userId to be 'testuser123'")
-               } else {
-                   XCTFail("Expected userId but found nil")
-               }
+        } else {
+            XCTFail("Expected userId but found nil")
+        }
         waitForDuration(seconds: 5)
-
+        
         if let events = localStorage.anonymousUserEvents {
-                XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-            } else {
-                XCTFail("Events were incorrectly cleared")
-            }
- 
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+        } else {
+            XCTFail("Events were incorrectly cleared")
+        }
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaMetUserIdDefault() {  // criteria met with merge default with setUserId
         let config = IterableConfig()
         config.enableAnonTracking = true
-        let internalAPI = IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+        IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
+        
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
+        
         if let anonUser = localStorage.userIdAnnon {
             XCTAssertFalse(anonUser.isEmpty, "Expected anon user nil")
-               } else {
-                   XCTFail("Expected anon user nil but found")
-               }
+        } else {
+            XCTFail("Expected anon user nil but found")
+        }
         
         IterableAPI.setUserId("testuser123")
-
+        
         // Verify "merge user" API call is made
-           let apiCallExpectation = self.expectation(description: "API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   // Pass the test if the API call was made
-                   apiCallExpectation.fulfill()
-               } else {
-                   XCTFail("Expected merge user API call was not made")
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let apiCallExpectation = self.expectation(description: "API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                // Pass the test if the API call was made
+                apiCallExpectation.fulfill()
+            } else {
+                XCTFail("Expected merge user API call was not made")
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaMetUserIdMergeFalse() {  // criteria met with merge false with setUserId
         let config = IterableConfig()
         config.enableAnonTracking = true
-        let internalAPI = IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+        IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
+        
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
+        
         if let anonUser = localStorage.userIdAnnon {
             XCTAssertFalse(anonUser.isEmpty, "Expected anon user to be found")
-               } else {
-                   XCTFail("Expected anon user but found nil")
-               }
+        } else {
+            XCTFail("Expected anon user but found nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: true, mergeOnAnonymousToKnown: false)
         IterableAPI.setUserId("testuser123", nil, identityResolution)
- 
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaMetUserIdMergeTrue() {  // criteria met with merge true with setUserId
         let config = IterableConfig()
         config.enableAnonTracking = true
-        let internalAPI = IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+        IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
+        
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
+        
         if let anonUser = localStorage.userIdAnnon {
             XCTAssertFalse(anonUser.isEmpty, "Expected anon user nil")
-               } else {
-                   XCTFail("Expected anon user nil but found")
-               }
+        } else {
+            XCTFail("Expected anon user nil but found")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: true, mergeOnAnonymousToKnown: true)
         IterableAPI.setUserId("testuser123", nil, identityResolution)
         
         waitForDuration(seconds: 3)
-
+        
         // Verify "merge user" API call is made
-           let apiCallExpectation = self.expectation(description: "API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   // Pass the test if the API call was made
-                   apiCallExpectation.fulfill()
-               } else {
-                   XCTFail("Expected merge user API call was not made")
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let apiCallExpectation = self.expectation(description: "API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                // Pass the test if the API call was made
+                apiCallExpectation.fulfill()
+            } else {
+                XCTFail("Expected merge user API call was not made")
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testIdentifiedUserIdDefault() {  // current user identified with setUserId default
         let config = IterableConfig()
         config.enableAnonTracking = true
-        let internalAPI = IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+        IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
+        
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.setUserId("testuser123")
         if let userId = IterableAPI.userId {
             XCTAssertEqual(userId, "testuser123", "Expected userId to be 'testuser123'")
-               } else {
-                   XCTFail("Expected userId but found nil")
-               }
+        } else {
+            XCTFail("Expected userId but found nil")
+        }
         
-       
+        
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
-
-        if let anonUser = localStorage.userIdAnnon {
-                XCTFail("Expected anon user nil but found")
-               } else {
-                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected anon user to be nil")
-               }
+        
+        
+        if localStorage.userIdAnnon != nil {
+            XCTFail("Expected anon user nil but found")
+        } else {
+            XCTAssertNil(localStorage.anonymousUserEvents, "Expected anon user to be nil")
+        }
         
         IterableAPI.setUserId("testuseranotheruser")
         if let userId = IterableAPI.userId {
             XCTAssertEqual(userId, "testuseranotheruser", "Expected userId to be 'testuseranotheruser'")
-               } else {
-                   XCTFail("Expected userId but found nil")
-               }
- 
+        } else {
+            XCTFail("Expected userId but found nil")
+        }
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     
     func testIdentifiedUserIdMergeFalse() {  // current user identified with setUserId merge false
         let config = IterableConfig()
         config.enableAnonTracking = true
-        let internalAPI = IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+        IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
+        
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.setUserId("testuser123")
         if let userId = IterableAPI.userId {
             XCTAssertEqual(userId, "testuser123", "Expected userId to be 'testuser123'")
-               } else {
-                   XCTFail("Expected userId but found nil")
-               }
+        } else {
+            XCTFail("Expected userId but found nil")
+        }
         
-       
+        
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
-        if let anonUser = localStorage.userIdAnnon {
-                XCTFail("Expected anon user nil but found")
-               } else {
-                   XCTAssertNil(localStorage.userIdAnnon, "Expected anon user to be nil")
-               }
+        
+        if localStorage.userIdAnnon != nil {
+            XCTFail("Expected anon user nil but found")
+        } else {
+            XCTAssertNil(localStorage.userIdAnnon, "Expected anon user to be nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: true, mergeOnAnonymousToKnown: false)
         IterableAPI.setUserId("testuseranotheruser", nil, identityResolution)
         
         if let userId = IterableAPI.userId {
             XCTAssertEqual(userId, "testuseranotheruser", "Expected userId to be 'testuseranotheruser'")
-               } else {
-                   XCTFail("Expected userId but found nil")
-               }
- 
+        } else {
+            XCTFail("Expected userId but found nil")
+        }
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     
@@ -477,436 +485,436 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
         let config = IterableConfig()
         config.enableAnonTracking = true
         IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.setUserId("testuser123")
         if let userId = IterableAPI.userId {
             XCTAssertEqual(userId, "testuser123", "Expected userId to be 'testuser123'")
-               } else {
-                   XCTFail("Expected userId but found nil")
-               }
+        } else {
+            XCTFail("Expected userId but found nil")
+        }
         
-       
+        
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
-
-        if let anonUser = localStorage.userIdAnnon {
-                XCTFail("Expected anon user nil but found")
-               } else {
-                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected anon user to be nil")
-               }
+        
+        
+        if localStorage.userIdAnnon != nil {
+            XCTFail("Expected anon user nil but found")
+        } else {
+            XCTAssertNil(localStorage.anonymousUserEvents, "Expected anon user to be nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: true, mergeOnAnonymousToKnown: true)
         IterableAPI.setUserId("testuseranotheruser", nil, identityResolution)
         waitForDuration(seconds: 3)
-
+        
         if let userId = IterableAPI.userId {
             XCTAssertEqual(userId, "testuseranotheruser", "Expected userId to be 'testuseranotheruser'")
-               } else {
-                   XCTFail("Expected userId but found nil")
-               }
- 
+        } else {
+            XCTFail("Expected userId but found nil")
+        }
+        
         // Verify "merge user" API call is not made
-           let apiCallExpectation = self.expectation(description: "API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   // Pass the test if the API call was made
-                   XCTFail("Expected merge user API call was made")
-               } else {
-                   apiCallExpectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let apiCallExpectation = self.expectation(description: "API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                // Pass the test if the API call was made
+                XCTFail("Expected merge user API call was made")
+            } else {
+                apiCallExpectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaNotMetEmailDefault() {  // criteria not met with merge default with setEmail
         let config = IterableConfig()
         config.enableAnonTracking = true
         IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent123")
-       
+        
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-               } else {
-                   XCTFail("Expected events to be logged but found nil")
-               }
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+        } else {
+            XCTFail("Expected events to be logged but found nil")
+        }
         
         IterableAPI.setEmail("testuser123@test.com")
         if let userId = IterableAPI.email {
             XCTAssertEqual(userId, "testuser123@test.com", "Expected email to be 'testuser123@test.com'")
-               } else {
-                   XCTFail("Expected email but found nil")
-               }
+        } else {
+            XCTFail("Expected email but found nil")
+        }
         waitForDuration(seconds: 5)
-
-        if let events = localStorage.anonymousUserEvents {
+        
+        if localStorage.anonymousUserEvents != nil {
             XCTFail("Events are not replayed")
         } else {
             XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
         }
- 
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaNotMetEmailReplayTrueMergeFalse() {  // criteria not met with merge false with setEmail
         let config = IterableConfig()
         config.enableAnonTracking = true
         IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent123")
-       
+        
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-               } else {
-                   XCTFail("Expected events to be logged but found nil")
-               }
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+        } else {
+            XCTFail("Expected events to be logged but found nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: true, mergeOnAnonymousToKnown: false)
         IterableAPI.setEmail("testuser123@test.com", nil, identityResolution)
         if let userId = IterableAPI.email {
             XCTAssertEqual(userId, "testuser123@test.com", "Expected email to be 'testuser123@test.com'")
-               } else {
-                   XCTFail("Expected email but found nil")
-               }
+        } else {
+            XCTFail("Expected email but found nil")
+        }
         
-        if let events = localStorage.anonymousUserEvents {
-                    XCTFail("Events are not replayed")
-               } else {
-                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
-               }
- 
+        if localStorage.anonymousUserEvents != nil {
+            XCTFail("Events are not replayed")
+        } else {
+            XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
+        }
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaNotMetEmailReplayFalseMergeFalse() {  // criteria not met with merge true with setEmail
         let config = IterableConfig()
         config.enableAnonTracking = true
         IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent123")
-       
+        
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-               } else {
-                   XCTFail("Expected events to be logged but found nil")
-               }
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+        } else {
+            XCTFail("Expected events to be logged but found nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: false, mergeOnAnonymousToKnown: false)
         IterableAPI.setEmail("testuser123@test.com", nil, identityResolution)
         if let userId = IterableAPI.email {
             XCTAssertEqual(userId, "testuser123@test.com", "Expected email to be 'testuser123@test.com'")
-               } else {
-                   XCTFail("Expected email but found nil")
-               }
+        } else {
+            XCTFail("Expected email but found nil")
+        }
         waitForDuration(seconds: 5)
-
+        
         if let events = localStorage.anonymousUserEvents {
             XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-            } else {
-                XCTFail("Events were incorrectly cleared")
-            }
- 
+        } else {
+            XCTFail("Events were incorrectly cleared")
+        }
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaNotMetEmailReplayFalseMergeTrue() {  // criteria not met with merge true with setEmail
         let config = IterableConfig()
         config.enableAnonTracking = true
         IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent123")
-       
+        
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-               } else {
-                   XCTFail("Expected events to be logged but found nil")
-               }
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
+        } else {
+            XCTFail("Expected events to be logged but found nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: false, mergeOnAnonymousToKnown: true)
         IterableAPI.setEmail("testuser123@test.com", nil, identityResolution)
         if let userId = IterableAPI.email {
             XCTAssertEqual(userId, "testuser123@test.com", "Expected email to be 'testuser123@test.com'")
-               } else {
-                   XCTFail("Expected email but found nil")
-               }
+        } else {
+            XCTFail("Expected email but found nil")
+        }
         waitForDuration(seconds: 5)
-
+        
         if let events = localStorage.anonymousUserEvents {
             XCTAssertFalse(events.isEmpty, "Expected events to be logged")
-            } else {
-                XCTFail("Events were incorrectly cleared")
-            }
- 
+        } else {
+            XCTFail("Events were incorrectly cleared")
+        }
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaMetEmailDefault() {  // criteria met with merge default with setEmail
         let config = IterableConfig()
         config.enableAnonTracking = true
-        let internalAPI = IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+        IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
+        
         if let anonUser = localStorage.userIdAnnon {
             XCTAssertFalse(anonUser.isEmpty, "Expected anon user")
-               } else {
-                   XCTFail("Expected anon user but found nil")
-               }
+        } else {
+            XCTFail("Expected anon user but found nil")
+        }
         
         IterableAPI.setEmail("testuser123@test.com")
-
+        
         // Verify "merge user" API call is made
-           let apiCallExpectation = self.expectation(description: "API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   // Pass the test if the API call was made
-                   apiCallExpectation.fulfill()
-               } else {
-                   XCTFail("Expected merge user API call was not made")
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let apiCallExpectation = self.expectation(description: "API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                // Pass the test if the API call was made
+                apiCallExpectation.fulfill()
+            } else {
+                XCTFail("Expected merge user API call was not made")
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaMetEmailMergeFalse() {  // criteria met with merge false with setEmail
         let config = IterableConfig()
         config.enableAnonTracking = true
-        let internalAPI = IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+        IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
+        
         if let anonUser = localStorage.userIdAnnon {
             XCTAssertFalse(anonUser.isEmpty, "Expected anon user")
-               } else {
-                   XCTFail("Expected anon user but found nil")
-               }
+        } else {
+            XCTFail("Expected anon user but found nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: true, mergeOnAnonymousToKnown: false)
         IterableAPI.setEmail("testuser123@test.com", nil, identityResolution)
- 
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCriteriaMetEmailMergeTrue() {  // criteria met with merge true with setEmail
         let config = IterableConfig()
         config.enableAnonTracking = true
-        let internalAPI = IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+        IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
+        
         if let anonUser = localStorage.userIdAnnon {
             XCTAssertFalse(anonUser.isEmpty, "Expected anon user")
-               } else {
-                   XCTFail("Expected anon user but found nil")
-               }
+        } else {
+            XCTFail("Expected anon user but found nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: true, mergeOnAnonymousToKnown: true)
         IterableAPI.setEmail("testuser123@test.com", nil, identityResolution)
-
+        
         // Verify "merge user" API call is made
-           let apiCallExpectation = self.expectation(description: "API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   // Pass the test if the API call was made
-                   apiCallExpectation.fulfill()
-               } else {
-                   XCTFail("Expected merge user API call was not made")
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let apiCallExpectation = self.expectation(description: "API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                // Pass the test if the API call was made
+                apiCallExpectation.fulfill()
+            } else {
+                XCTFail("Expected merge user API call was not made")
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testIdentifiedEmailDefault() {  // current user identified with setEmail default
         let config = IterableConfig()
         config.enableAnonTracking = true
-        let internalAPI = IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+        IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.setEmail("testuser123@test.com")
         if let userId = IterableAPI.email {
             XCTAssertEqual(userId, "testuser123@test.com", "Expected email to be 'testuser123@test.com'")
-               } else {
-                   XCTFail("Expected email but found nil")
-               }
+        } else {
+            XCTFail("Expected email but found nil")
+        }
         
-       
+        
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
-
-        if let anonUser = localStorage.userIdAnnon {
-                XCTFail("Expected anon user nil but found")
-               } else {
-                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected anon user to be nil")
-               }
+        
+        
+        if localStorage.userIdAnnon != nil {
+            XCTFail("Expected anon user nil but found")
+        } else {
+            XCTAssertNil(localStorage.anonymousUserEvents, "Expected anon user to be nil")
+        }
         
         IterableAPI.setEmail("testuseranotheruser@test.com")
         if let userId = IterableAPI.email {
             XCTAssertEqual(userId, "testuseranotheruser@test.com", "Expected email to be 'testuseranotheruser@test.com'")
-               } else {
-                   XCTFail("Expected email but found nil")
-               }
- 
+        } else {
+            XCTFail("Expected email but found nil")
+        }
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testIdentifiedEmailMergeFalse() {  // current user identified with setEmail merge false
         let config = IterableConfig()
         config.enableAnonTracking = true
-        let internalAPI = IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+        IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.setEmail("testuser123@test.com")
         if let userId = IterableAPI.email {
             XCTAssertEqual(userId, "testuser123@test.com", "Expected email to be 'testuser123@test.com'")
-               } else {
-                   XCTFail("Expected email but found nil")
-               }
+        } else {
+            XCTFail("Expected email but found nil")
+        }
         
-       
+        
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
-
-        if let anonUser = localStorage.userIdAnnon {
-                XCTFail("Expected anon user nil but found")
-               } else {
-                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected anon user to be nil")
-               }
+        
+        
+        if localStorage.userIdAnnon != nil {
+            XCTFail("Expected anon user nil but found")
+        } else {
+            XCTAssertNil(localStorage.anonymousUserEvents, "Expected anon user to be nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: true, mergeOnAnonymousToKnown: false)
         IterableAPI.setEmail("testuseranotheruser@test.com", nil, identityResolution)
         if let userId = IterableAPI.email {
             XCTAssertEqual(userId, "testuseranotheruser@test.com", "Expected email to be 'testuseranotheruser@test.com'")
-               } else {
-                   XCTFail("Expected email but found nil")
-               }
- 
+        } else {
+            XCTFail("Expected email but found nil")
+        }
+        
         // Verify "merge user" API call is not made
-           let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        let expectation = self.expectation(description: "No API call is made to merge user")
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     
@@ -914,53 +922,53 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
         let config = IterableConfig()
         config.enableAnonTracking = true
         IterableAPI.initializeForTesting(apiKey: UserMergeScenariosTests.apiKey,
-                                                                   config: config,
-                                                                   networkSession: mockSession,
-                                                                   localStorage: localStorage)
+                                         config: config,
+                                         networkSession: mockSession,
+                                         localStorage: localStorage)
         IterableAPI.logoutUser()
         guard let jsonData = mockData.data(using: .utf8) else { return }
         localStorage.criteriaData = jsonData
         IterableAPI.setEmail("testuser123@test.com")
         if let userId = IterableAPI.email {
             XCTAssertEqual(userId, "testuser123@test.com", "Expected email to be 'testuser123@test.com'")
-               } else {
-                   XCTFail("Expected email but found nil")
-               }
+        } else {
+            XCTFail("Expected email but found nil")
+        }
         
-       
+        
         IterableAPI.track(event: "testEvent")
         waitForDuration(seconds: 3)
-
-
+        
+        
         if localStorage.userIdAnnon != nil {
-                XCTFail("Expected anon user nil but found")
-               } else {
-                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected anon user to be nil")
-               }
+            XCTFail("Expected anon user nil but found")
+        } else {
+            XCTAssertNil(localStorage.anonymousUserEvents, "Expected anon user to be nil")
+        }
         
         let identityResolution = IterableIdentityResolution(replayOnVisitorToKnown: true, mergeOnAnonymousToKnown: true)
         IterableAPI.setEmail("testuseranotheruser@test.com", nil, identityResolution)
         waitForDuration(seconds: 3)
-
+        
         if let userId = IterableAPI.email {
             XCTAssertEqual(userId, "testuseranotheruser@test.com", "Expected email to be 'testuseranotheruser@test.com'")
-               } else {
-                   XCTFail("Expected email but found nil")
-               }
- 
+        } else {
+            XCTFail("Expected email but found nil")
+        }
+        
         // Verify "merge user" API call is made
         let expectation = self.expectation(description: "No API call is made to merge user")
-           DispatchQueue.main.async {
-               if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
-                   // Pass the test if the API call was made
-                   XCTFail("merge user API call was made unexpectedly")
-               } else {
-                   // Pass the test if the API call was not made
-                   expectation.fulfill()
-               }
-           }
-           
-           waitForExpectations(timeout: 5, handler: nil)
+        DispatchQueue.main.async {
+            if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
+                // Pass the test if the API call was made
+                XCTFail("merge user API call was made unexpectedly")
+            } else {
+                // Pass the test if the API call was not made
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
     }
 }
 

--- a/tests/unit-tests/ValidateStoredEventCheckUnknownToKnownUserTest.swift
+++ b/tests/unit-tests/ValidateStoredEventCheckUnknownToKnownUserTest.swift
@@ -58,7 +58,7 @@ final class ValidateStoredEventCheckUnknownToKnownUserTest: XCTestCase, AuthProv
 
         IterableAPI.setUserId("testuser123")
 
-        if let events = self.localStorage.anonymousUserEvents {
+        if self.localStorage.anonymousUserEvents != nil {
             XCTFail("Events are not replayed")
         } else {
             XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-9646](https://iterable.atlassian.net/browse/MOB-9646)

## ✏️ Description

> This pull request aligns the unit test naming with the Android SDK and also adds tests to cover all the identity resolution combinations.


[MOB-9646]: https://iterable.atlassian.net/browse/MOB-9646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ