### PR TITLE
Stopping Core Data Crashes When Disk is Full

### DIFF
--- a/swift-sdk/Internal/DependencyContainerProtocol.swift
+++ b/swift-sdk/Internal/DependencyContainerProtocol.swift
@@ -17,7 +17,7 @@ protocol DependencyContainerProtocol: RedirectNetworkSessionProvider {
     var apnsTypeChecker: APNSTypeCheckerProtocol { get }
     
     func createInAppFetcher(apiClient: ApiClientProtocol) -> InAppFetcherProtocol
-    func createPersistenceContextProvider() -> IterablePersistenceContextProvider?
+    func createPersistenceContextProvider() -> IterablePersistenceContextProvider
     func createRequestHandler(apiKey: String,
                               config: IterableConfig,
                               endpoint: String,
@@ -83,12 +83,7 @@ extension DependencyContainerProtocol {
                                                      dateProvider: dateProvider)
         lazy var offlineProcessor: OfflineRequestProcessor? = nil
         lazy var healthMonitor: HealthMonitor? = nil
-        guard let persistenceContextProvider = createPersistenceContextProvider() else {
-            return RequestHandler(onlineProcessor: onlineProcessor,
-                                  offlineProcessor: nil,
-                                  healthMonitor: nil,
-                                  offlineMode: offlineMode)
-        }
+        let persistenceContextProvider = createPersistenceContextProvider()
         if offlineMode {
             
             let healthMonitorDataProvider = createHealthMonitorDataProvider(persistenceContextProvider: persistenceContextProvider)
@@ -124,7 +119,7 @@ extension DependencyContainerProtocol {
         HealthMonitorDataProvider(maxTasks: 1000, persistenceContextProvider: persistenceContextProvider)
     }
     
-    func createPersistenceContextProvider() -> IterablePersistenceContextProvider? {
+    func createPersistenceContextProvider() -> IterablePersistenceContextProvider {
         CoreDataPersistenceContextProvider(dateProvider: dateProvider)
     }
     

--- a/swift-sdk/Internal/IterableCoreDataPersistence.swift
+++ b/swift-sdk/Internal/IterableCoreDataPersistence.swift
@@ -12,7 +12,7 @@ enum PersistenceConst {
     enum Entity {
         enum Task {
             static let name = "IterableTaskManagedObject"
-            
+
             enum Column {
                 static let id = "id"
                 static let scheduledAt = "scheduledAt"
@@ -21,16 +21,17 @@ enum PersistenceConst {
     }
 }
 
-class PersistentContainer: NSPersistentContainer {
-    static var shared: PersistentContainer?
-    
-    static func initialize() -> PersistentContainer? {
-        if shared == nil {
-            shared = create()
-        }
-        return shared
+let sharedManagedObjectModel: NSManagedObjectModel? = {
+    guard let url = PersistentContainer.dataModelUrl(fromBundles: [Bundle.main, Bundle(for: PersistentContainer.self)]) else {
+        ITBError("Could not find \(PersistenceConst.dataModelFileName).\(PersistenceConst.dataModelExtension) in bundle")
+        return nil
     }
-    
+    ITBInfo("DB Bundle url: \(url)")
+    return NSManagedObjectModel(contentsOf: url)
+}()
+
+final class PersistentContainer: NSPersistentContainer, @unchecked Sendable {
+
     override func newBackgroundContext() -> NSManagedObjectContext {
         let backgroundContext = super.newBackgroundContext()
         backgroundContext.automaticallyMergesChangesFromParent = true
@@ -38,65 +39,77 @@ class PersistentContainer: NSPersistentContainer {
         return backgroundContext
     }
 
-    private static func create() -> PersistentContainer? {
-        guard let managedObjectModel = createManagedObjectModel() else {
-            ITBError("Could not initialize managed object model")
-            return nil
+    override init(
+        name: String = PersistenceConst.dataModelFileName,
+        managedObjectModel: NSManagedObjectModel? = sharedManagedObjectModel
+    ) {
+        if let managedObjectModel {
+            super.init(name: name, managedObjectModel: managedObjectModel)
+        } else {
+            super.init(name: name)
         }
-        let container = PersistentContainer(name: PersistenceConst.dataModelFileName, managedObjectModel: managedObjectModel)
-        container.loadPersistentStores { desc, error in
-            if let error = error {
-                ITBError("Unresolved error when creating PersistentContainer: \(error)")
-            }
-            
-            ITBInfo("Successfully loaded persistent store at: \(desc.url?.description ?? "nil")")
-        }
-        
-        container.viewContext.automaticallyMergesChangesFromParent = true
-        container.viewContext.mergePolicy = NSMergePolicy(merge: NSMergePolicyType.mergeByPropertyStoreTrumpMergePolicyType)
-        
-        return container
+        viewContext.automaticallyMergesChangesFromParent = true
+        viewContext.mergePolicy = NSMergePolicy(merge: NSMergePolicyType.mergeByPropertyStoreTrumpMergePolicyType)
     }
-    
-    private static func createManagedObjectModel() -> NSManagedObjectModel? {
-        guard let url = dataModelUrl(fromBundles: [Bundle.main, Bundle(for: PersistentContainer.self)]) else {
-            ITBError("Could not find \(PersistenceConst.dataModelFileName).\(PersistenceConst.dataModelExtension) in bundle")
-            return nil
-        }
-        ITBInfo("DB Bundle url: \(url)")
-        return NSManagedObjectModel(contentsOf: url)
-    }
-    
-    private static func dataModelUrl(fromBundles bundles: [Bundle]) -> URL? {
+
+    static func dataModelUrl(fromBundles bundles: [Bundle]) -> URL? {
         bundles.lazy.compactMap(dataModelUrl(fromBundle:)).first
     }
-    
+
     private static func dataModelUrl(fromBundle bundle: Bundle) -> URL? {
-        ResourceHelper.url(forResource: PersistenceConst.dataModelFileName,
-                           withExtension: PersistenceConst.dataModelExtension,
-                           fromBundle: bundle)
+        ResourceHelper.url(
+            forResource: PersistenceConst.dataModelFileName,
+            withExtension: PersistenceConst.dataModelExtension,
+            fromBundle: bundle
+        )
     }
 }
 
-struct CoreDataPersistenceContextProvider: IterablePersistenceContextProvider {
-    init?(dateProvider: DateProviderProtocol = SystemDateProvider()) {
-        guard let persistentContainer = PersistentContainer.initialize() else {
-            return nil
-        }
+final class CoreDataPersistenceContextProvider: IterablePersistenceContextProvider {
+    init(
+        dateProvider: DateProviderProtocol = SystemDateProvider(),
+        persistentContainer: NSPersistentContainer = PersistentContainer()
+    ) {
         self.persistentContainer = persistentContainer
         self.dateProvider = dateProvider
     }
-    
+
     func newBackgroundContext() -> IterablePersistenceContext {
+        if !isStoreLoaded {
+            isStoreLoaded = loadStore(into: persistentContainer)
+        }
         return CoreDataPersistenceContext(managedObjectContext: persistentContainer.newBackgroundContext(), dateProvider: dateProvider)
     }
-    
+
     func mainQueueContext() -> IterablePersistenceContext {
+        if !isStoreLoaded {
+            isStoreLoaded = loadStore(into: persistentContainer)
+        }
         return CoreDataPersistenceContext(managedObjectContext: persistentContainer.viewContext, dateProvider: dateProvider)
     }
-    
-    private let persistentContainer: PersistentContainer
+
+    private let persistentContainer: NSPersistentContainer
     private let dateProvider: DateProviderProtocol
+    private var isStoreLoaded = false
+
+    /// Loads the persistent container synchronously so we can easily capture loading errors.
+    private func loadStore(into container: NSPersistentContainer) -> Bool {
+        if let descriptor = container.persistentStoreDescriptions.first {
+            descriptor.shouldAddStoreAsynchronously = false
+        }
+
+        // This closure runs synchronously because of the settings above
+        var loadError: (any Error)?
+        container.loadPersistentStores { _, error in
+            loadError = error
+        }
+
+        if let error = loadError {
+            ITBError("Failed to load Iterable's store. \(error.localizedDescription)")
+            return false
+        }
+        return true
+    }
 }
 
 struct CoreDataPersistenceContext: IterablePersistenceContext {
@@ -104,60 +117,62 @@ struct CoreDataPersistenceContext: IterablePersistenceContext {
         self.managedObjectContext = managedObjectContext
         self.dateProvider = dateProvider
     }
-    
+
     func create(task: IterableTask) throws -> IterableTask {
         guard let taskManagedObject = createTaskManagedObject() else {
             throw IterableDBError.general("Could not create task managed object")
         }
-        
+
         PersistenceHelper.copy(from: task, to: taskManagedObject)
         taskManagedObject.createdAt = dateProvider.currentDate
         return PersistenceHelper.task(from: taskManagedObject)
     }
-    
+
     func update(task: IterableTask) throws -> IterableTask {
         guard let taskManagedObject = try findTaskManagedObject(id: task.id) else {
             throw IterableDBError.general("Could not find task to update")
         }
-        
+
         PersistenceHelper.copy(from: task, to: taskManagedObject)
         taskManagedObject.modifiedAt = dateProvider.currentDate
         return PersistenceHelper.task(from: taskManagedObject)
     }
-    
+
     func delete(task: IterableTask) throws {
         try deleteTask(withId: task.id)
     }
 
     func nextTask() throws -> IterableTask? {
-        let taskManagedObjects: [IterableTaskManagedObject] = try CoreDataUtil.findSortedEntities(context: managedObjectContext,
-                                                                                                  entity: PersistenceConst.Entity.Task.name,
-                                                                                                  column: PersistenceConst.Entity.Task.Column.scheduledAt,
-                                                                                                  ascending: true,
-                                                                                                  limit: 1)
+        let taskManagedObjects: [IterableTaskManagedObject] = try CoreDataUtil.findSortedEntities(
+            context: managedObjectContext,
+            entity: PersistenceConst.Entity.Task.name,
+            column: PersistenceConst.Entity.Task.Column.scheduledAt,
+            ascending: true,
+            limit: 1
+        )
         return taskManagedObjects.first.map(PersistenceHelper.task(from:))
     }
-    
+
     func findTask(withId id: String) throws -> IterableTask? {
         guard let taskManagedObject = try findTaskManagedObject(id: id) else {
             return nil
         }
         return PersistenceHelper.task(from: taskManagedObject)
     }
-    
+
     func deleteTask(withId id: String) throws {
         guard let taskManagedObject = try findTaskManagedObject(id: id) else {
             return
         }
         managedObjectContext.delete(taskManagedObject)
     }
-    
+
     func findAllTasks() throws -> [IterableTask] {
         let taskManagedObjects: [IterableTaskManagedObject] = try CoreDataUtil.findAll(context: managedObjectContext, entity: PersistenceConst.Entity.Task.name)
-        
+
         return taskManagedObjects.map(PersistenceHelper.task(from:))
     }
-    
+
     func deleteAllTasks() throws {
         let taskManagedObjects: [IterableTaskManagedObject] = try CoreDataUtil.findAll(context: managedObjectContext, entity: PersistenceConst.Entity.Task.name)
         taskManagedObjects.forEach {
@@ -168,34 +183,41 @@ struct CoreDataPersistenceContext: IterablePersistenceContext {
             }
         }
     }
-    
+
     func countTasks() throws -> Int {
-        return try CoreDataUtil.count(context: managedObjectContext, entity: PersistenceConst.Entity.Task.name)
+        try CoreDataUtil.count(context: managedObjectContext, entity: PersistenceConst.Entity.Task.name)
     }
-    
+
     func save() throws {
+        // Guard against Objective-C exceptions which cannot be caught in Swift.
+        guard
+            let coordinator = managedObjectContext.persistentStoreCoordinator,
+            !coordinator.persistentStores.isEmpty
+        else {
+            throw NSError(domain: NSCocoaErrorDomain, code: NSPersistentStoreSaveError)
+        }
         try managedObjectContext.save()
     }
-    
+
     func perform(_ block: @escaping () -> Void) {
         managedObjectContext.perform(block)
     }
-    
+
     func performAndWait(_ block: () -> Void) {
         managedObjectContext.performAndWait(block)
     }
-    
+
     func performAndWait<T>(_ block: () throws -> T) throws -> T {
         try managedObjectContext.performAndWait(block)
     }
-    
+
     private let managedObjectContext: NSManagedObjectContext
     private let dateProvider: DateProviderProtocol
-    
+
     private func findTaskManagedObject(id: String) throws -> IterableTaskManagedObject? {
         try CoreDataUtil.findEntitiyByColumn(context: managedObjectContext, entity: PersistenceConst.Entity.Task.name, columnName: PersistenceConst.Entity.Task.Column.id, columnValue: id)
     }
-    
+
     private func createTaskManagedObject() -> IterableTaskManagedObject? {
         CoreDataUtil.create(context: managedObjectContext, entity: PersistenceConst.Entity.Task.name)
     }

--- a/tests/common/CommonExtensions.swift
+++ b/tests/common/CommonExtensions.swift
@@ -129,7 +129,7 @@ class MockDependencyContainer: DependencyContainerProtocol {
         HealthMonitorDataProvider(maxTasks: maxTasks, persistenceContextProvider: persistenceContextProvider)
     }
     
-    func createPersistenceContextProvider() -> IterablePersistenceContextProvider? {
+    func createPersistenceContextProvider() -> IterablePersistenceContextProvider {
         if let persistenceContextProvider = persistenceContextProvider {
             return persistenceContextProvider
         } else {

--- a/tests/endpoint-tests/OfflineModeE2ETests.swift
+++ b/tests/endpoint-tests/OfflineModeE2ETests.swift
@@ -81,42 +81,45 @@ class OfflineModeEndpointTests: XCTestCase {
                 "messageId": "msg_1",
             ],
         ]
-        api.trackPushOpen(pushPayload,
-                          dataFields: ["data_field1": "value1"],
-                          onSuccess: { _ in
-                              expectation1.fulfill()
-        }) { reason, _ in
+        api.trackPushOpen(
+            pushPayload,
+            dataFields: ["data_field1": "value1"],
+            onSuccess: { _ in
+                expectation1.fulfill()
+            }
+        ) { reason, _ in
             XCTFail(reason ?? "failed")
         }
-        
+
         wait(for: [expectation1], timeout: 15)
     }
-    
+
     func test04TrackEvent() throws {
         let expectation1 = expectation(description: #function)
         let localStorage = MockLocalStorage()
         localStorage.offlineMode = true
-        let api = InternalIterableAPI.initializeForE2E(apiKey: Self.apiKey,
-                                                       localStorage: localStorage)
+        let api = InternalIterableAPI.initializeForE2E(
+            apiKey: Self.apiKey,
+            localStorage: localStorage
+        )
         api.email = "user@example.com"
-        
-        api.track("event1",
-                  dataFields: ["data_field1": "value1"],
-                  onSuccess: { _ in
-                      expectation1.fulfill()
-        }) { reason, _ in
+
+        api.track(
+            "event1",
+            dataFields: ["data_field1": "value1"],
+            onSuccess: { _ in
+                expectation1.fulfill()
+            }
+        ) { reason, _ in
             XCTFail(reason ?? "failed")
         }
-        
+
         wait(for: [expectation1], timeout: 15)
     }
-    
+
     private static let apiKey = Environment.apiKey!
     private static let pushCampaignId = Environment.pushCampaignId!
     private static let pushTemplateId = Environment.pushTemplateId!
     private static let inAppCampaignId = Environment.inAppCampaignId!
-    private lazy var persistenceContextProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider()!
-        return provider
-    }()
+    private lazy var persistenceContextProvider: IterablePersistenceContextProvider = CoreDataPersistenceContextProvider()
 }

--- a/tests/offline-events-tests/HealthMonitorTests.swift
+++ b/tests/offline-events-tests/HealthMonitorTests.swift
@@ -226,7 +226,7 @@ class HealthMonitorTests: XCTestCase {
     private let dateProvider = MockDateProvider()
     
     private lazy var persistenceProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider)!
+        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider)
         try! provider.mainQueueContext().deleteAllTasks()
         try! provider.mainQueueContext().save()
         return provider

--- a/tests/offline-events-tests/RequestHandlerTests.swift
+++ b/tests/offline-events-tests/RequestHandlerTests.swift
@@ -1170,7 +1170,7 @@ class RequestHandlerTests: XCTestCase {
     private let dateProvider = MockDateProvider()
     
     private lazy var persistenceContextProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider)!
+        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider)
         return provider
     }()
 }

--- a/tests/offline-events-tests/TaskProcessorTests.swift
+++ b/tests/offline-events-tests/TaskProcessorTests.swift
@@ -253,7 +253,7 @@ class TaskProcessorTests: XCTestCase {
                                                 appPackageName: Bundle.main.appPackageName ?? "")
 
     private lazy var persistenceProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider()!
+        let provider = CoreDataPersistenceContextProvider()
         try! provider.mainQueueContext().deleteAllTasks()
         try! provider.mainQueueContext().save()
         return provider

--- a/tests/offline-events-tests/TaskRunnerTests.swift
+++ b/tests/offline-events-tests/TaskRunnerTests.swift
@@ -411,7 +411,7 @@ class TaskRunnerTests: XCTestCase {
                                                 appPackageName: Bundle.main.appPackageName ?? "")
     
     private lazy var persistenceContextProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider()!
+        let provider = CoreDataPersistenceContextProvider()
         return provider
     }()
 }

--- a/tests/offline-events-tests/TaskSchedulerTests.swift
+++ b/tests/offline-events-tests/TaskSchedulerTests.swift
@@ -114,7 +114,7 @@ class TaskSchedulerTests: XCTestCase {
                                                 appPackageName: Bundle.main.appPackageName ?? "")
 
     private lazy var persistenceContextProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider)!
+        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider)
         return provider
     }()
 

--- a/tests/offline-events-tests/TasksCRUDTests.swift
+++ b/tests/offline-events-tests/TasksCRUDTests.swift
@@ -214,7 +214,7 @@ class TasksCRUDTests: XCTestCase {
     private let dateProvider = MockDateProvider()
     
     private lazy var persistenceProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider)!
+        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider)
         try! provider.mainQueueContext().deleteAllTasks()
         try! provider.mainQueueContext().save()
         return provider


### PR DESCRIPTION
## Description

This PR prevents a crash which occurs when Core Data's persistent store fails to load. Loading the persistent store can fail for several reasons: the database could be corrupted, the disk might be full, or from a bad migration. This also might occur when the app wakes up in the background and the persistent store didn't load in time.

When using `NSPersistentContainer` it's important to handle any errors from `loadPersistentStores(_:)` since they're recoverable. If you ignore this error, then Core Data throws an Objective-C exception which cannot be handled in Swift when you try to save.

Previous PR #816 

## Crash
<img width="1442" alt="364360709-8e10ca27-4490-4449-9652-3d4792a657bc" src="https://github.com/user-attachments/assets/b39da5bb-440d-43d4-8e95-942f2ae30499">

The crash originates from `IterableTaskScheduler.deleteAllTasks()` which calls try `persistenceContext.save()` and throws:

```
NSInternalInconsistencyException - This NSPersistentStoreCoordinator has no persistent stores (disk full). It cannot perform a save operation.
          Fatal Exception: NSInternalInconsistencyException
0  CoreFoundation                 0x9cb4 __exceptionPreprocess
1  libobjc.A.dylib                0x183d0 objc_exception_throw
2  CoreData                       0x192388 -[NSPersistentStoreCoordinator _introspectLastErrorAndThrow]
3  CoreData                       0x19288c __65-[NSPersistentStoreCoordinator executeRequest:withContext:error:]_block_invoke.551
4  CoreData                       0x5f678 -[NSPersistentStoreCoordinator _routeHeavyweightBlock:]
5  CoreData                       0x256d8 -[NSPersistentStoreCoordinator executeRequest:withContext:error:]
6  CoreData                       0x256fc -[NSPersistentStoreCoordinator executeRequest:withContext:error:]
7  CoreData                       0x88220 -[NSManagedObjectContext save:]
8  Fetch Rewards                  0x1876084 closure #1 in IterableTaskScheduler.deleteAllTasks() + 177 (IterableCoreDataPersistence.swift:177)
9  Fetch Rewards                  0x18c3dcc thunk for @escaping @callee_guaranteed () -> () (<compiler-generated>)
10 CoreData                       0x80b6c developerSubmittedBlockToNSManagedObjectContextPerform
11 libdispatch.dylib              0x3eac _dispatch_client_callout
12 libdispatch.dylib              0xb534 _dispatch_lane_serial_drain
13 libdispatch.dylib              0xc0a4 _dispatch_lane_invoke
14 libdispatch.dylib              0x16cdc _dispatch_workloop_worker_thread
15 libsystem_pthread.dylib        0xddc _pthread_wqthread
16 libsystem_pthread.dylib        0xb7c start_wqthread
```