### PR TITLE
[MOB-10136] clears local storage when replay is false

### DIFF
--- a/swift-sdk/Internal/AnonymousUserManager.swift
+++ b/swift-sdk/Internal/AnonymousUserManager.swift
@@ -167,8 +167,6 @@ public class AnonymousUserManager: AnonymousUserManagerProtocol {
             
             IterableAPI.implementation?.updateUser(userUpdate, mergeNestedObjects: false)
         }
-        
-        clearVisitorEventsAndUserData()
     }
     
     public func clearVisitorEventsAndUserData() {

--- a/swift-sdk/Internal/AnonymousUserManagerProtocol.swift
+++ b/swift-sdk/Internal/AnonymousUserManagerProtocol.swift
@@ -14,4 +14,5 @@ import Foundation
     func updateAnonSession()
     func getAnonCriteria()
     func syncEvents()
+    func clearVisitorEventsAndUserData()
 }

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -231,6 +231,7 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
             } else {
                 failureHandler?(error, nil)
             }
+            self.anonymousUserManager.clearVisitorEventsAndUserData()
         }
     }
 

--- a/tests/unit-tests/UserMergeScenariosTests.swift
+++ b/tests/unit-tests/UserMergeScenariosTests.swift
@@ -202,19 +202,20 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
         }
         waitForDuration(seconds: 5)
         
+        let expectation1 = self.expectation(description: "Events properly cleared")
         if let events = localStorage.anonymousUserEvents {
             XCTAssertFalse(events.isEmpty, "Expected events to be logged")
         } else {
-            XCTFail("Events were incorrectly cleared")
+            expectation1.fulfill()
         }
         
         // Verify "merge user" API call is not made
-        let expectation = self.expectation(description: "No API call is made to merge user")
+        let expectation2 = self.expectation(description: "No API call is made to merge user")
         DispatchQueue.main.async {
             if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
                 XCTFail("merge user API call was made unexpectedly")
             } else {
-                expectation.fulfill()
+                expectation2.fulfill()
             }
         }
         
@@ -250,19 +251,20 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
         }
         waitForDuration(seconds: 5)
         
+        let expectation1 = self.expectation(description: "Events properly cleared")
         if let events = localStorage.anonymousUserEvents {
             XCTAssertFalse(events.isEmpty, "Expected events to be logged")
         } else {
-            XCTFail("Events were incorrectly cleared")
+            expectation1.fulfill()
         }
         
         // Verify "merge user" API call is not made
-        let expectation = self.expectation(description: "No API call is made to merge user")
+        let expectation2 = self.expectation(description: "No API call is made to merge user")
         DispatchQueue.main.async {
             if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
                 XCTFail("merge user API call was made unexpectedly")
             } else {
-                expectation.fulfill()
+                expectation2.fulfill()
             }
         }
         
@@ -649,19 +651,20 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
         }
         waitForDuration(seconds: 5)
         
+        let expectation1 = self.expectation(description: "Events properly cleared")
         if let events = localStorage.anonymousUserEvents {
             XCTAssertFalse(events.isEmpty, "Expected events to be logged")
         } else {
-            XCTFail("Events were incorrectly cleared")
+            expectation1.fulfill()
         }
         
         // Verify "merge user" API call is not made
-        let expectation = self.expectation(description: "No API call is made to merge user")
+        let expectation2 = self.expectation(description: "No API call is made to merge user")
         DispatchQueue.main.async {
             if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
                 XCTFail("merge user API call was made unexpectedly")
             } else {
-                expectation.fulfill()
+                expectation2.fulfill()
             }
         }
         
@@ -695,19 +698,20 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
         }
         waitForDuration(seconds: 5)
         
+        let expectation1 = self.expectation(description: "Events properly cleared")
         if let events = localStorage.anonymousUserEvents {
             XCTAssertFalse(events.isEmpty, "Expected events to be logged")
         } else {
-            XCTFail("Events were incorrectly cleared")
+            expectation1.fulfill()
         }
         
         // Verify "merge user" API call is not made
-        let expectation = self.expectation(description: "No API call is made to merge user")
+        let expectation2 = self.expectation(description: "No API call is made to merge user")
         DispatchQueue.main.async {
             if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
                 XCTFail("merge user API call was made unexpectedly")
             } else {
-                expectation.fulfill()
+                expectation2.fulfill()
             }
         }
         


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-10136](https://iterable.atlassian.net/browse/MOB-10136)

## ✏️ Description

> This pull request updates attemptAndProcessMerge to clear the local storage when replay is false.


[MOB-10136]: https://iterable.atlassian.net/browse/MOB-10136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ