### PR TITLE
[MOB-10104] Fix wakey notification tracking event on did finish launch with options 

### DIFF
--- a/swift-sdk/Constants.swift
+++ b/swift-sdk/Constants.swift
@@ -95,6 +95,11 @@ enum Const {
         static let location = "Location"
         static let setCookie = "Set-Cookie"
     }
+    
+    enum RemoteNotification {
+        static let aps = "aps"
+        static let contentAvailable = "content-available"
+    }
 }
 
 enum JsonKey {

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -706,7 +706,16 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         guard let launchOptions = launchOptions else {
             return
         }
+        
         if let remoteNotificationPayload = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [AnyHashable: Any] {
+            
+            if let aps = remoteNotificationPayload["aps"] as? [String: Any],
+               let contentAvailable = aps["content-available"] as? Int,
+               contentAvailable == 1 {
+                ITBInfo("Received push notification with wakey content-available flag")
+                return
+            }
+            
             if let _ = IterableUtil.rootViewController {
                 // we are ready
                 IterableAppIntegration.implementation?.performDefaultNotificationAction(remoteNotificationPayload)

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -709,8 +709,8 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         
         if let remoteNotificationPayload = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [AnyHashable: Any] {
             
-            if let aps = remoteNotificationPayload["aps"] as? [String: Any],
-               let contentAvailable = aps["content-available"] as? Int,
+            if let aps = remoteNotificationPayload[Const.RemoteNotification.aps] as? [String: Any],
+               let contentAvailable = aps[Const.RemoteNotification.contentAvailable] as? Int,
                contentAvailable == 1 {
                 ITBInfo("Received push notification with wakey content-available flag")
                 return


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-10104](https://iterable.atlassian.net/browse/MOB-10104)

## ✏️ Description

When a Push notification with the Wakey feature tuned on — `"content-available": 1` — the SDK was tracking a pushOpen event incorrectly.

Now we actively check if it's a wakey push notification and prevent that tracking — unless the user actually taps on the notification and opens the app.


[MOB-10104]: https://iterable.atlassian.net/browse/MOB-10104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ