### PR TITLE
[MOB-10468] prepare version 6.5.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.5.8]
+### Fixed
+- Fixed incorrect tracking of pushOpen for push notifications with Wake App enabled. Tracking now happens only when users tap to open the app.
+
+### Changed
+- Updated repository name on Fastline script and podspec files.
+- Comments out outdated tests that need to be revisited
+- Updated sample app to use generic URLs
+
 ## [6.5.7]
 ### Fixed
 - Fixed deeplink re-routing issue where delegate would only return `false` value. Thanks to @scottasoutherland :) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [6.5.8]
 ### Fixed
 - Fixed incorrect tracking of pushOpen for push notifications with Wake App enabled. Tracking now happens only when users tap to open the app.
-- Fixed the default `notificationsEnabled` value returned when `autoPushRegistration` is set to `false`
+- Fixed the default `notificationsEnabled` value returned when `autoPushRegistration` is set to `false`.
 
 ### Changed
 - Updated repository name on Fastline script and podspec files.
-- Comments out outdated tests that need to be revisited
-- Updated sample app to use generic URLs
+- Comments out outdated tests that need to be revisited.
+- Updated sample app to use generic URLs.
 
 ## [6.5.7]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [6.5.8]
 ### Fixed
 - Fixed incorrect tracking of pushOpen for push notifications with Wake App enabled. Tracking now happens only when users tap to open the app.
+- Fixed the default `notificationsEnabled` value returned when `autoPushRegistration` is set to `false`
 
 ### Changed
 - Updated repository name on Fastline script and podspec files.

--- a/Iterable-iOS-AppExtensions.podspec
+++ b/Iterable-iOS-AppExtensions.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "Iterable-iOS-AppExtensions"
   s.module_name  = "IterableAppExtensions"
-  s.version      = "6.5.7"
+  s.version      = "6.5.8"
   s.summary      = "App Extensions for Iterable SDK"
 
   s.description  = <<-DESC

--- a/Iterable-iOS-SDK.podspec
+++ b/Iterable-iOS-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "Iterable-iOS-SDK"
   s.module_name  = "IterableSDK"
-  s.version      = "6.5.7"
+  s.version      = "6.5.8"
   s.summary      = "Iterable's official SDK for iOS"
 
   s.description  = <<-DESC

--- a/swift-sdk/IterableAPI.swift
+++ b/swift-sdk/IterableAPI.swift
@@ -7,7 +7,7 @@ import UIKit
 
 @objcMembers public final class IterableAPI: NSObject {
     /// The current SDK version
-    public static let sdkVersion = "6.5.7"
+    public static let sdkVersion = "6.5.8"
     
     /// The email of the logged in user that this IterableAPI is using
     public static var email: String? {


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-10468](https://iterable.atlassian.net/browse/MOB-10468)

## ✏️ Description

> This pull request prepares for the version 6.5.8 release.


[MOB-10468]: https://iterable.atlassian.net/browse/MOB-10468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ