### PR TITLE
[MOB-10592] Make IterableAPIMobileFrameworkInfo properties and initia…

### DIFF
--- a/swift-sdk/SDK/IterableConfig.swift
+++ b/swift-sdk/SDK/IterableConfig.swift
@@ -11,8 +11,14 @@ public enum IterableAPIMobileFrameworkType: String, Codable {
 }
 
 public struct IterableAPIMobileFrameworkInfo: Codable {
-    let frameworkType: IterableAPIMobileFrameworkType
-    let iterableSdkVersion: String?
+    public let frameworkType: IterableAPIMobileFrameworkType
+    public let iterableSdkVersion: String?
+    
+    // MARK: - Public Initializer
+    public init(frameworkType: IterableAPIMobileFrameworkType, iterableSdkVersion: String?) {
+        self.frameworkType = frameworkType
+        self.iterableSdkVersion = iterableSdkVersion
+    }
 }
 
 /// Custom URL handling delegate

--- a/swift-sdk/SDK/IterableConfig.swift
+++ b/swift-sdk/SDK/IterableConfig.swift
@@ -14,7 +14,6 @@ public struct IterableAPIMobileFrameworkInfo: Codable {
     public let frameworkType: IterableAPIMobileFrameworkType
     public let iterableSdkVersion: String?
     
-    // MARK: - Public Initializer
     public init(frameworkType: IterableAPIMobileFrameworkType, iterableSdkVersion: String?) {
         self.frameworkType = frameworkType
         self.iterableSdkVersion = iterableSdkVersion


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-10576](https://iterable.atlassian.net/browse/MOB-10576?focusedCommentId=353196)

## ✏️ Description

PR Description
This PR addresses MOB-10576 by adding a public initializer to IterableAPIMobileFrameworkInfo, allowing integrators to instantiate it directly without JSON decoding. This clears the previous limitation caused by the Swift compiler’s internal-only synthesized constructor.




[MOB-10576]: https://iterable.atlassian.net/browse/MOB-10576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ