### PR TITLE
MOB-9982 Embedded messaging crash when image fails to load

### DIFF
--- a/swift-sdk/ui-components/uikit/IterableEmbeddedView.swift
+++ b/swift-sdk/ui-components/uikit/IterableEmbeddedView.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 @IBDesignable
-public class IterableEmbeddedView:UIView {
+public class IterableEmbeddedView: UIView {
     
     /// Set background color of view in container view.
     @IBOutlet weak public var contentView: UIView!
@@ -290,10 +290,6 @@ public class IterableEmbeddedView:UIView {
                 cardImageTopConstraint.isActive = false
                 titleToTopConstraint.isActive = true
                 titleToTopConstraint?.isActive = true
-                
-                // Remove cardImageView from its superview and release it
-                cardImageView?.removeFromSuperview()
-                cardImageView = nil
             }
         case .banner:
             imgView?.isHidden = EMimage == nil

--- a/swift-sdk/ui-components/uikit/IterableEmbeddedView.swift
+++ b/swift-sdk/ui-components/uikit/IterableEmbeddedView.swift
@@ -219,6 +219,9 @@ public class IterableEmbeddedView:UIView {
 
         let view = nib.instantiate(withOwner: self, options: nil).first as? UIView
         self.clipsToBounds = false
+        
+        self.imgView.image = UIImage(resource: ImageResource.loading)
+        self.cardImageView.image = UIImage(resource: ImageResource.loading)
         return view
     }
 

--- a/swift-sdk/ui-components/uikit/IterableEmbeddedView.swift
+++ b/swift-sdk/ui-components/uikit/IterableEmbeddedView.swift
@@ -32,8 +32,8 @@ public class IterableEmbeddedView:UIView {
     @IBOutlet weak var horizontalButtonStackViewSpacer: UIView!
     
     /// IterableEmbeddedView Image View.
-    @IBOutlet weak public var imgView: UIImageView!
-    @IBOutlet weak public var cardImageView: UIImageView!
+    @IBOutlet weak public var imgView: UIImageView?
+    @IBOutlet weak public var cardImageView: UIImageView?
     @IBOutlet var cardImageTopConstraint: NSLayoutConstraint!
     @IBOutlet var titleToTopConstraint: NSLayoutConstraint!
     
@@ -219,9 +219,6 @@ public class IterableEmbeddedView:UIView {
 
         let view = nib.instantiate(withOwner: self, options: nil).first as? UIView
         self.clipsToBounds = false
-        
-        self.imgView.image = UIImage(resource: ImageResource.loading)
-        self.cardImageView.image = UIImage(resource: ImageResource.loading)
         return view
     }
 
@@ -277,46 +274,46 @@ public class IterableEmbeddedView:UIView {
         
     private func loadViewType(viewType: IterableEmbeddedViewType) {
         switch viewType {
-            case .card:
-                imgView.isHidden = true
-                let shouldShowCardImageView = EMimage != nil
-                if shouldShowCardImageView {
-                    // Show cardImageView
-                    cardImageView.image = EMimage
-                    cardImageView.isHidden = false
-                    cardImageTopConstraint.isActive = true
-                    titleToTopConstraint.isActive = false
-                    titleToTopConstraint?.isActive = false
-                } else {
-                    // Hide cardImageView and deactivate its constraints
-                    cardImageView.isHidden = true
-                    cardImageTopConstraint.isActive = false
-                    titleToTopConstraint.isActive = true
-                    titleToTopConstraint?.isActive = true
-
-                    // Remove cardImageView from its superview and release it
-                    cardImageView.removeFromSuperview()
-                    cardImageView = nil
-                }
-            case .banner:
-                imgView.isHidden = EMimage == nil
-                imgView.isHidden = self.EMimage == nil
-                imgView.image = EMimage
-                if !imgView.isHidden {
-                    imgView.widthAnchor.constraint(equalToConstant: 100).isActive = true
-                }
-                cardImageView.isHidden = true
+        case .card:
+            imgView?.isHidden = true
+            let shouldShowCardImageView = EMimage != nil
+            if shouldShowCardImageView {
+                // Show cardImageView
+                cardImageView?.image = EMimage
+                cardImageView?.isHidden = false
+                cardImageTopConstraint.isActive = true
+                titleToTopConstraint.isActive = false
+                titleToTopConstraint?.isActive = false
+            } else {
+                // Hide cardImageView and deactivate its constraints
+                cardImageView?.isHidden = true
                 cardImageTopConstraint.isActive = false
                 titleToTopConstraint.isActive = true
-                cardImageTopConstraint?.isActive = false
                 titleToTopConstraint?.isActive = true
-            case .notification:
-                imgView.isHidden = true
-                cardImageView.isHidden = true
-                cardImageTopConstraint.isActive = false
-                titleToTopConstraint.isActive = true
-                cardImageTopConstraint?.isActive = false
-                titleToTopConstraint?.isActive = true
+                
+                // Remove cardImageView from its superview and release it
+                cardImageView?.removeFromSuperview()
+                cardImageView = nil
+            }
+        case .banner:
+            imgView?.isHidden = EMimage == nil
+            imgView?.isHidden = self.EMimage == nil
+            imgView?.image = EMimage
+            if let imageView = imgView, !imageView.isHidden {
+                imgView?.widthAnchor.constraint(equalToConstant: 100).isActive = true
+            }
+            cardImageView?.isHidden = true
+            cardImageTopConstraint.isActive = false
+            titleToTopConstraint.isActive = true
+            cardImageTopConstraint?.isActive = false
+            titleToTopConstraint?.isActive = true
+        case .notification:
+            imgView?.isHidden = true
+            cardImageView?.isHidden = true
+            cardImageTopConstraint.isActive = false
+            titleToTopConstraint.isActive = true
+            cardImageTopConstraint?.isActive = false
+            titleToTopConstraint?.isActive = true
         }
     }
     


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-9982](https://iterable.atlassian.net/browse/MOB-9982)

## ✏️ Description

Instead of force unwrapping a potential nil value stored on the imgView and cardImageView components, we now use optionals to prevent a crash.


[MOB-9982]: https://iterable.atlassian.net/browse/MOB-9982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ