### PR TITLE
[MOB-11789] call consent logging after event replay completes

### DIFF
--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -154,17 +154,23 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
             let merge = identityResolution?.mergeOnUnknownUserToKnown ?? config.identityResolution.mergeOnUnknownUserToKnown
             let replay = identityResolution?.replayOnVisitorToKnown ?? config.identityResolution.replayOnVisitorToKnown
             if config.enableUnknownUserActivation, let email = email {
+                // Capture original unknown user state before clearing it
+                let originalUnknownUserId = self?.localStorage.userIdUnknownUser
+                
                 self?.attemptAndProcessMerge(
                     merge: merge ?? true,
                     replay: replay ?? true,
                     destinationUser: email,
                     isEmail: true,
-                    failureHandler: failureHandler
+                    failureHandler: failureHandler,
+                    onReplayComplete: {
+                        // Send consent for replay scenario only after replay events are successfully processed
+                        // Check if this is truly a replay scenario (no existing anonymous user before merge)
+                        if let replay, replay, originalUnknownUserId == nil {
+                            self?.sendConsentForReplayScenario(email: email, userId: nil)
+                        }
+                    }
                 )
-                // Send consent for replay scenario only if replay events is enabled
-                if let replay, replay {
-                    self?.sendConsentForReplayScenario(email: email, userId: nil)
-                }
                 
                 self?.localStorage.userIdUnknownUser = nil
             }
@@ -198,6 +204,9 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                 return
             }
             if config.enableUnknownUserActivation {
+                // Capture original unknown user state before clearing it
+                let originalUnknownUserId = self?.localStorage.userIdUnknownUser
+                
                 if let userId = userId, userId != (self?.localStorage.userIdUnknownUser ?? "") {
                     let merge = identityResolution?.mergeOnUnknownUserToKnown ?? config.identityResolution.mergeOnUnknownUserToKnown
                     let replay = identityResolution?.replayOnVisitorToKnown ?? config.identityResolution.replayOnVisitorToKnown
@@ -206,12 +215,15 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                         replay: replay ?? true,
                         destinationUser: userId,
                         isEmail: false,
-                        failureHandler: failureHandler
+                        failureHandler: failureHandler,
+                        onReplayComplete: {
+                            // Send consent for replay scenario only after replay events are successfully processed
+                            // Check if this is truly a replay scenario (no existing anonymous user before merge)
+                            if let replay, replay, originalUnknownUserId == nil {
+                                self?.sendConsentForReplayScenario(email: nil, userId: userId)
+                            }
+                        }
                     )
-                    // Send consent for replay scenario only if replay events is enabled
-                    if let replay, replay {
-                        self?.sendConsentForReplayScenario(email: nil, userId: userId)
-                    }
                 }
 
                 if !isUnknownUser {
@@ -230,17 +242,19 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         logoutPreviousUser()
     }
     
-    func attemptAndProcessMerge(merge: Bool, replay: Bool, destinationUser: String?, isEmail: Bool, failureHandler: OnFailureHandler? = nil) {
+    func attemptAndProcessMerge(merge: Bool, replay: Bool, destinationUser: String?, isEmail: Bool, failureHandler: OnFailureHandler? = nil, onReplayComplete: (() -> Void)? = nil) {
         unknownUserMerge.tryMergeUser(destinationUser: destinationUser, isEmail: isEmail, merge: merge) { mergeResult, error in
             
             if mergeResult == MergeResult.mergenotrequired ||  mergeResult == MergeResult.mergesuccessful {
                 if (replay) {
                     self.unknownUserManager.syncEvents()
+                    // Execute the completion callback after replay events are synced
+                    onReplayComplete?()
                 }
             } else {
                 failureHandler?(error, nil)
             }
-                            self.unknownUserManager.clearVisitorEventsAndUserData()
+            self.unknownUserManager.clearVisitorEventsAndUserData()
         }
     }
 


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-11789](https://iterable.atlassian.net/browse/MOB-11789)

## ✏️ Description

> This pull request updates the consent logging flow to call the consent logging endpoint after the event replay completes. Addresses bug where consent logging was called before the new user was created.


[MOB-11789]: https://iterable.atlassian.net/browse/MOB-11789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ