### PR TITLE
MOB-12033 Renamed CoreData method for iOS 26 compatibility

### DIFF
--- a/swift-sdk/Internal/CoreDataUtil.swift
+++ b/swift-sdk/Internal/CoreDataUtil.swift
@@ -74,7 +74,8 @@ struct CoreDataUtil {
 }
 
 extension NSManagedObjectContext {
-    func performAndWait<T>(_ block: () throws -> T) throws -> T {
+    @available(iOS, obsoleted: 15.0, message: "This method is intended for older versions of iOS")
+    func performActionAndWait<T>(_ block: () throws -> T) throws -> T {
         var result: Result<T, Error>?
         performAndWait {
             result = Result { try block() }

--- a/swift-sdk/Internal/IterableCoreDataPersistence.swift
+++ b/swift-sdk/Internal/IterableCoreDataPersistence.swift
@@ -186,7 +186,11 @@ struct CoreDataPersistenceContext: IterablePersistenceContext {
     }
     
     func performAndWait<T>(_ block: () throws -> T) throws -> T {
-        try managedObjectContext.performAndWait(block)
+        if #available(iOS 15.0, *) {
+            try managedObjectContext.performAndWait(block)
+        } else {
+            try managedObjectContext.performActionAndWait(block)
+        }
     }
     
     private let managedObjectContext: NSManagedObjectContext


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-12033](https://iterable.atlassian.net/browse/MOB-12033)

## ✏️ Description

Renames a conflicting method name with the native CoreData one.
Versions older than iOS 15 will use the custom method, newer versions will use the native one.

#### Acknowledgements
Thank you @fnazarios and @rajusa420 for raising this issue!

[MOB-12033]: https://iterable.atlassian.net/browse/MOB-12033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ