### PR TITLE
SDK-199 Auth Retry policy completely bypassed

### DIFF
--- a/swift-sdk/Internal/AuthManager.swift
+++ b/swift-sdk/Internal/AuthManager.swift
@@ -67,8 +67,16 @@ class AuthManager: IterableAuthManagerProtocol {
     }
     
     private func shouldPauseRetry(_ shouldIgnoreRetryPolicy: Bool) -> Bool {
-        return (!shouldIgnoreRetryPolicy && pauseAuthRetry) ||
-               (retryCount >= authRetryPolicy.maxRetry && !shouldIgnoreRetryPolicy)
+        if pauseAuthRetry {
+            return true
+        }
+        
+        // Scheduled refresh should never bypass retry safety limits.
+        if isInScheduledRefreshCallback {
+            return retryCount >= authRetryPolicy.maxRetry
+        }
+        
+        return retryCount >= authRetryPolicy.maxRetry && !shouldIgnoreRetryPolicy
     }
     
     private func shouldUseLastValidToken(_ shouldIgnoreRetryPolicy: Bool) -> Bool {
@@ -113,6 +121,7 @@ class AuthManager: IterableAuthManagerProtocol {
     private var isLastAuthTokenValid: Bool = false
     private var pauseAuthRetry: Bool = false
     private var isTimerScheduled: Bool = false
+    private var isInScheduledRefreshCallback: Bool = false
     
     private var pendingSuccessCallbacks: [AuthTokenRetrievalHandler] = []
     private let callbackQueue = DispatchQueue(label: "com.iterable.authCallbackQueue")
@@ -205,6 +214,7 @@ class AuthManager: IterableAuthManagerProtocol {
         let timeIntervalToRefresh = TimeInterval(expirationDate) - dateProvider.currentDate.timeIntervalSince1970 - expirationRefreshPeriod
         if timeIntervalToRefresh > 0 {
             scheduleAuthTokenRefreshTimer(interval: timeIntervalToRefresh, isScheduledRefresh: true, successCallback: onSuccess)
+            resetRetryCount()
             return true  // Only return true when we successfully queue a refresh
         }
         return false
@@ -228,11 +238,14 @@ class AuthManager: IterableAuthManagerProtocol {
         addPendingCallback(successCallback)
         
         expirationRefreshTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
-            self?.isTimerScheduled = false
-            if self?.localStorage.email != nil || self?.localStorage.userId != nil {
-                self?.requestNewAuthToken(hasFailedPriorAuth: false, onSuccess: { [weak self] token in
+            guard let self else { return }
+            self.isTimerScheduled = false
+            if self.localStorage.email != nil || self.localStorage.userId != nil {
+                self.isInScheduledRefreshCallback = isScheduledRefresh
+                self.requestNewAuthToken(hasFailedPriorAuth: false, onSuccess: { [weak self] token in
                     self?.invokePendingCallbacks(with: token)
                 }, shouldIgnoreRetryPolicy: isScheduledRefresh)
+                self.isInScheduledRefreshCallback = false
             } else {
                 ITBDebug("Email or userId is not available. Skipping token refresh")
                 self?.clearPendingCallbacks()

--- a/swift-sdk/Internal/AuthManager.swift
+++ b/swift-sdk/Internal/AuthManager.swift
@@ -248,7 +248,7 @@ class AuthManager: IterableAuthManagerProtocol {
                 self.isInScheduledRefreshCallback = false
             } else {
                 ITBDebug("Email or userId is not available. Skipping token refresh")
-                self?.clearPendingCallbacks()
+                self.clearPendingCallbacks()
             }
         }
         


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [SDK-199](https://iterable.atlassian.net/browse/SDK-199)

## ✏️ Description

Fixes auth retry for expired JWT refresh: scheduled token refresh no longer bypasses `pauseAuthRetries` or `authRetryPolicy.maxRetry`, preventing runaway/infinite `onAuthTokenRequested` loops. 

Added unit tests to lock pause + maxRetry behavior on scheduled refresh, and reset retry count after a successful refresh is queued.


[SDK-199]: https://iterable.atlassian.net/browse/SDK-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ